### PR TITLE
set up a satellite-of-love REST service on Travis

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -1,0 +1,16 @@
+---
+kind: "operation"
+client: "atomist-bot"
+editor:
+  name: "AddDeploymentSpec"
+  group: "satellite-of-love"
+  artifact: "new-project-rugs"
+  version: "0.1.6"
+  origin:
+    repo: "git@github.com:satellite-of-love/new-project-rugs"
+    branch: "master"
+    sha: "a0d2633"
+  parameters:
+    - "service": "berlin"
+    - "path": "wood"
+

--- a/60-berlin-svc.json
+++ b/60-berlin-svc.json
@@ -1,0 +1,28 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "berlin",
+	"annotations": {
+	  "atomist.dnsmode" : "vanity",
+          "atomist.elb-service-name" : "kong",
+          "atomist.upstream_url" : "http://berlin:8080",
+          "atomist.vanity-name" : "survey.atomist.com",
+          "atomist.request_path": "/berlin-path"
+	}
+    },
+    "spec": {
+        "selector": {
+            "app": "berlin"
+        },
+        "ports": [
+            {
+                "name": "berlin",
+                "protocol": "TCP",
+                "port": 8080,
+                "targetPort": 8080
+            }
+        ]
+    }
+}
+ 

--- a/80-berlin-deployment.json
+++ b/80-berlin-deployment.json
@@ -1,0 +1,73 @@
+{
+  "apiVersion" : "extensions/v1beta1",
+  "kind" : "Deployment",
+  "metadata" : {
+    "name" : "berlin"
+  },
+  "spec" : {
+    "replicas" : 1,
+    "revisionHistoryLimit" : 3,
+    "selector" : {
+      "matchLabels" : {
+        "app" : "berlin"
+      }
+    },
+    "template" : {
+      "metadata" : {
+        "name" : "berlin",
+        "labels" : {
+          "app" : "berlin"
+        },
+        "annotations" : {
+          "atomist.config" : "{}",
+          "atomist.updater" : "{sforzando-docker-dockerv2-local.artifactoryonline.com/berlin satellite-of-love/berlin}"
+        }
+      },
+      "spec" : {
+        "containers" : [ {
+          "name" : "berlin",
+          "image" : "sforzando-docker-dockerv2-local.artifactoryonline.com/berlin:0.1.0-SNAPSHOT",
+          "imagePullPolicy" : "Always",
+          "resources" : {
+            "limits" : {
+              "cpu" : 0.5,
+              "memory" : "1024Mi"
+            },
+            "requests" : {
+              "cpu" : 0.1,
+              "memory" : "768Mi"
+            }
+          },
+          "env" : [ {
+            "name" : "PORT",
+            "value" : "8080"
+          }, {
+            "name" : "DOMAIN",
+            "valueFrom" : {
+              "secretKeyRef" : {
+                "name" : "atomist-domain",
+                "key" : "name"
+              }
+            }
+          }, {
+            "name" : "APP_NAME",
+            "value" : "berlin"
+          } ],
+          "ports" : [ {
+            "containerPort" : 8080
+          } ]
+        } ],
+        "imagePullSecrets" : [ {
+          "name" : "atomistregistrykey"
+        } ]
+      }
+    },
+    "strategy" : {
+      "type" : "RollingUpdate",
+      "rollingUpdate" : {
+        "maxUnavailable" : 0,
+        "maxSurge" : 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
Created by Atomist Editor `AddDeploymentSpec`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "AddDeploymentSpec"
  group: "satellite-of-love"
  artifact: "new-project-rugs"
  version: "0.1.6"
  origin:
    repo: "git@github.com:satellite-of-love/new-project-rugs"
    branch: "master"
    sha: "a0d2633"
  parameters:
    - "service": "berlin"
    - "path": "wood"

```