### PR TITLE
set up a satellite-of-love REST service on Travis

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -14,3 +14,19 @@ editor:
     - "service": "berlin"
     - "path": "wood"
 
+---
+kind: "operation"
+client: "atomist-bot"
+editor:
+  name: "AddDeploymentSpec"
+  group: "satellite-of-love"
+  artifact: "new-project-rugs"
+  version: "0.1.11"
+  origin:
+    repo: "git@github.com:satellite-of-love/new-project-rugs"
+    branch: "master"
+    sha: "d2ab330*"
+  parameters:
+    - "service": "workflow-rugs"
+    - "path": "tomorrow"
+

--- a/60-workflow-rugs-svc.json
+++ b/60-workflow-rugs-svc.json
@@ -1,0 +1,28 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "workflow-rugs",
+	"annotations": {
+	  "atomist.dnsmode" : "vanity",
+          "atomist.elb-service-name" : "kong",
+          "atomist.upstream_url" : "http://workflow-rugs:8080",
+          "atomist.vanity-name" : "survey.atomist.com",
+          "atomist.request_path": "/tomorrow"
+	}
+    },
+    "spec": {
+        "selector": {
+            "app": "workflow-rugs"
+        },
+        "ports": [
+            {
+                "name": "workflow-rugs",
+                "protocol": "TCP",
+                "port": 8080,
+                "targetPort": 8080
+            }
+        ]
+    }
+}
+ 

--- a/80-workflow-rugs-deployment.json
+++ b/80-workflow-rugs-deployment.json
@@ -1,0 +1,73 @@
+{
+  "apiVersion" : "extensions/v1beta1",
+  "kind" : "Deployment",
+  "metadata" : {
+    "name" : "workflow-rugs"
+  },
+  "spec" : {
+    "replicas" : 1,
+    "revisionHistoryLimit" : 3,
+    "selector" : {
+      "matchLabels" : {
+        "app" : "workflow-rugs"
+      }
+    },
+    "template" : {
+      "metadata" : {
+        "name" : "workflow-rugs",
+        "labels" : {
+          "app" : "workflow-rugs"
+        },
+        "annotations" : {
+          "atomist.config" : "{}",
+          "atomist.updater" : "{sforzando-docker-dockerv2-local.artifactoryonline.com/workflow-rugs satellite-of-love/workflow-rugs}"
+        }
+      },
+      "spec" : {
+        "containers" : [ {
+          "name" : "workflow-rugs",
+          "image" : "sforzando-docker-dockerv2-local.artifactoryonline.com/workflow-rugs:0.1.0-SNAPSHOT",
+          "imagePullPolicy" : "Always",
+          "resources" : {
+            "limits" : {
+              "cpu" : 0.5,
+              "memory" : "1024Mi"
+            },
+            "requests" : {
+              "cpu" : 0.1,
+              "memory" : "768Mi"
+            }
+          },
+          "env" : [ {
+            "name" : "PORT",
+            "value" : "8080"
+          }, {
+            "name" : "DOMAIN",
+            "valueFrom" : {
+              "secretKeyRef" : {
+                "name" : "atomist-domain",
+                "key" : "name"
+              }
+            }
+          }, {
+            "name" : "APP_NAME",
+            "value" : "workflow-rugs"
+          } ],
+          "ports" : [ {
+            "containerPort" : 8080
+          } ]
+        } ],
+        "imagePullSecrets" : [ {
+          "name" : "atomistregistrykey"
+        } ]
+      }
+    },
+    "strategy" : {
+      "type" : "RollingUpdate",
+      "rollingUpdate" : {
+        "maxUnavailable" : 0,
+        "maxSurge" : 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
Say hello to a new service, workflow-rugs
        
        Merge this PR only after the Travis build has published some artifact for this service, please.

Created by Atomist Editor `AddDeploymentSpec`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "AddDeploymentSpec"
  group: "satellite-of-love"
  artifact: "new-project-rugs"
  version: "0.1.11"
  origin:
    repo: "git@github.com:satellite-of-love/new-project-rugs"
    branch: "master"
    sha: "d2ab330*"
  parameters:
    - "service": "workflow-rugs"
    - "path": "tomorrow"

```