### PR TITLE
set up a satellite-of-love REST service on Travis

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -14,3 +14,19 @@ editor:
     - "service": "berlin"
     - "path": "wood"
 
+---
+kind: "operation"
+client: "atomist-bot"
+editor:
+  name: "AddDeploymentSpec"
+  group: "satellite-of-love"
+  artifact: "new-project-rugs"
+  version: "0.1.14"
+  origin:
+    repo: "git@github.com:satellite-of-love/new-project-rugs"
+    branch: "master"
+    sha: "ed7c82f*"
+  parameters:
+    - "service": "amsterdam"
+    - "path": "amsterdam"
+

--- a/60-amsterdam-svc.json
+++ b/60-amsterdam-svc.json
@@ -1,0 +1,28 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "amsterdam",
+	"annotations": {
+	  "atomist.dnsmode" : "vanity",
+          "atomist.elb-service-name" : "kong",
+          "atomist.upstream_url" : "http://amsterdam:8080",
+          "atomist.vanity-name" : "survey.atomist.com",
+          "atomist.request_path": "/amsterdam"
+	}
+    },
+    "spec": {
+        "selector": {
+            "app": "amsterdam"
+        },
+        "ports": [
+            {
+                "name": "amsterdam",
+                "protocol": "TCP",
+                "port": 8080,
+                "targetPort": 8080
+            }
+        ]
+    }
+}
+ 

--- a/80-amsterdam-deployment.json
+++ b/80-amsterdam-deployment.json
@@ -1,0 +1,73 @@
+{
+  "apiVersion" : "extensions/v1beta1",
+  "kind" : "Deployment",
+  "metadata" : {
+    "name" : "amsterdam"
+  },
+  "spec" : {
+    "replicas" : 1,
+    "revisionHistoryLimit" : 3,
+    "selector" : {
+      "matchLabels" : {
+        "app" : "amsterdam"
+      }
+    },
+    "template" : {
+      "metadata" : {
+        "name" : "amsterdam",
+        "labels" : {
+          "app" : "amsterdam"
+        },
+        "annotations" : {
+          "atomist.config" : "{}",
+          "atomist.updater" : "{sforzando-docker-dockerv2-local.artifactoryonline.com/amsterdam satellite-of-love/amsterdam}"
+        }
+      },
+      "spec" : {
+        "containers" : [ {
+          "name" : "amsterdam",
+          "image" : "sforzando-docker-dockerv2-local.artifactoryonline.com/amsterdam:0.1.0-SNAPSHOT",
+          "imagePullPolicy" : "Always",
+          "resources" : {
+            "limits" : {
+              "cpu" : 0.5,
+              "memory" : "1024Mi"
+            },
+            "requests" : {
+              "cpu" : 0.1,
+              "memory" : "768Mi"
+            }
+          },
+          "env" : [ {
+            "name" : "PORT",
+            "value" : "8080"
+          }, {
+            "name" : "DOMAIN",
+            "valueFrom" : {
+              "secretKeyRef" : {
+                "name" : "atomist-domain",
+                "key" : "name"
+              }
+            }
+          }, {
+            "name" : "APP_NAME",
+            "value" : "amsterdam"
+          } ],
+          "ports" : [ {
+            "containerPort" : 8080
+          } ]
+        } ],
+        "imagePullSecrets" : [ {
+          "name" : "atomistregistrykey"
+        } ]
+      }
+    },
+    "strategy" : {
+      "type" : "RollingUpdate",
+      "rollingUpdate" : {
+        "maxUnavailable" : 0,
+        "maxSurge" : 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
Say hello to a new service, amsterdam
        
        Merge this PR only after the Travis build has published some artifact for this service, please.

Created by Atomist Editor `AddDeploymentSpec`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "AddDeploymentSpec"
  group: "satellite-of-love"
  artifact: "new-project-rugs"
  version: "0.1.14"
  origin:
    repo: "git@github.com:satellite-of-love/new-project-rugs"
    branch: "master"
    sha: "ed7c82f*"
  parameters:
    - "service": "amsterdam"
    - "path": "amsterdam"

```