### PR TITLE
set up a satellite-of-love REST service on Travis

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -89,3 +89,19 @@ editor:
     - "service": "henley-on-thames"
     - "path": "henley-on-thames"
 
+---
+kind: "operation"
+client: "atomist-bot"
+editor:
+  name: "AddDeploymentSpec"
+  group: "satellite-of-love"
+  artifact: "new-project-rugs"
+  version: "0.1.22"
+  origin:
+    repo: "git@github.com:satellite-of-love/new-project-rugs"
+    branch: "master"
+    sha: "29e6449"
+  parameters:
+    - "service": "random-kitty-adoption"
+    - "path": "philly"
+

--- a/60-random-kitty-adoption-svc.json
+++ b/60-random-kitty-adoption-svc.json
@@ -1,0 +1,28 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "random-kitty-adoption",
+	"annotations": {
+	  "atomist.dnsmode" : "vanity",
+          "atomist.elb-service-name" : "kong",
+          "atomist.upstream_url" : "http://random-kitty-adoption:8080",
+          "atomist.vanity-name" : "survey.atomist.com",
+          "atomist.request_path": "/philly"
+	}
+    },
+    "spec": {
+        "selector": {
+            "app": "random-kitty-adoption"
+        },
+        "ports": [
+            {
+                "name": "random-kitty-adoption",
+                "protocol": "TCP",
+                "port": 8080,
+                "targetPort": 8080
+            }
+        ]
+    }
+}
+ 

--- a/80-random-kitty-adoption-deployment.json
+++ b/80-random-kitty-adoption-deployment.json
@@ -1,0 +1,73 @@
+{
+  "apiVersion" : "extensions/v1beta1",
+  "kind" : "Deployment",
+  "metadata" : {
+    "name" : "random-kitty-adoption"
+  },
+  "spec" : {
+    "replicas" : 1,
+    "revisionHistoryLimit" : 3,
+    "selector" : {
+      "matchLabels" : {
+        "app" : "random-kitty-adoption"
+      }
+    },
+    "template" : {
+      "metadata" : {
+        "name" : "random-kitty-adoption",
+        "labels" : {
+          "app" : "random-kitty-adoption"
+        },
+        "annotations" : {
+          "atomist.config" : "{}",
+          "atomist.updater" : "{sforzando-docker-dockerv2-local.artifactoryonline.com/random-kitty-adoption satellite-of-love/random-kitty-adoption}"
+        }
+      },
+      "spec" : {
+        "containers" : [ {
+          "name" : "random-kitty-adoption",
+          "image" : "sforzando-docker-dockerv2-local.artifactoryonline.com/random-kitty-adoption:0.1.0-SNAPSHOT",
+          "imagePullPolicy" : "Always",
+          "resources" : {
+            "limits" : {
+              "cpu" : 0.5,
+              "memory" : "512Mi"
+            },
+            "requests" : {
+              "cpu" : 0.1,
+              "memory" : "256Mi"
+            }
+          },
+          "env" : [ {
+            "name" : "PORT",
+            "value" : "8080"
+          }, {
+            "name" : "DOMAIN",
+            "valueFrom" : {
+              "secretKeyRef" : {
+                "name" : "atomist-domain",
+                "key" : "name"
+              }
+            }
+          }, {
+            "name" : "APP_NAME",
+            "value" : "random-kitty-adoption"
+          } ],
+          "ports" : [ {
+            "containerPort" : 8080
+          } ]
+        } ],
+        "imagePullSecrets" : [ {
+          "name" : "atomistregistrykey"
+        } ]
+      }
+    },
+    "strategy" : {
+      "type" : "RollingUpdate",
+      "rollingUpdate" : {
+        "maxUnavailable" : 0,
+        "maxSurge" : 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
Say hello to a new service, random-kitty-adoption
        
        Merge this PR only after the Travis build has published some artifact for this service, please.

Created by Atomist Editor `AddDeploymentSpec`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "AddDeploymentSpec"
  group: "satellite-of-love"
  artifact: "new-project-rugs"
  version: "0.1.22"
  origin:
    repo: "git@github.com:satellite-of-love/new-project-rugs"
    branch: "master"
    sha: "29e6449"
  parameters:
    - "service": "random-kitty-adoption"
    - "path": "philly"

```