### PR TITLE
add an endpoint to return a POJO

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -44,3 +44,29 @@ editor:
     branch: "master"
     sha: "c23ed53"
 
+---
+kind: "operation"
+client: "atomist-bot"
+editor:
+  name: "AddRestEndpoint"
+  group: "satellite-of-love"
+  artifact: "rest-service-generator"
+  version: "0.12.5"
+  origin:
+    repo: "git@github.com:satellite-of-love/rest-service-generator"
+    branch: "master"
+    sha: "89b8555"
+  parameters:
+    - "returnedClass": "Survey"
+    - "fieldName": "seed"
+    - "fieldType": "Int"
+    - "repo": "atomist-k8-specs"
+    - "handle": "{}"
+    - "__mappedParameters": "{"0":{"localKey":"repo","foreignKey":"atomist://github/repository"}}"
+    - "__parameters": "{"0":{"displayName":"Java return type","description":"type the endpoint will return","pattern":"@java_class","validInput":"Java class name like ThunderCougarFalconBird","minLength":1,"maxLength":100,"name":"returnedClass","decorated":true},"1":{"displayName":"pojo field name","description":"name of a field in your pojo, blank for none (or not a new pojo)","pattern":"@java_identifier","validInput":"Java identifier","minLength":1,"maxLength":100,"name":"fieldName","decorated":true},"2":{"displayName":"pojo field type","description":"type of that field in your pojo, blank for none (or not a new pojo)","pattern":"@any","validInput":"Java type","minLength":1,"maxLength":100,"name":"fieldType","decorated":true}}"
+    - "__intent": "{"0":"add endpoint"}"
+    - "__tags": "{"0":"satellite-of-love","1":"rest"}"
+    - "__name": "AddRestEndpointPlease"
+    - "__description": "run an editor to add a REST endpoint to this project"
+    - "__kind": "command-handler"
+

--- a/src/main/java/com/jessitron/Survey.java
+++ b/src/main/java/com/jessitron/Survey.java
@@ -1,0 +1,22 @@
+package com.jessitron;
+
+public class Survey {
+
+    // default constructor for deserialization
+    public Survey() {
+    }
+
+    public Int seed;
+
+    public Int getSeed() {
+        return seed;
+    }
+
+    public void setSeed(Int seed) {
+        this.seed = seed;
+    }
+
+    public Survey(Int seed) {
+        this.seed = seed;
+    }
+}

--- a/src/main/java/com/jessitron/SurveyController.java
+++ b/src/main/java/com/jessitron/SurveyController.java
@@ -1,0 +1,16 @@
+package com.jessitron;
+
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SurveyController {
+
+    @CrossOrigin()
+    @RequestMapping(path = "/survey")
+    public Survey survey(@RequestParam(value = "seed") Int seed) {
+        return new Survey(seed);
+    }
+}

--- a/src/test/java/com/jessitron/SurveyWebIntegrationTests.java
+++ b/src/test/java/com/jessitron/SurveyWebIntegrationTests.java
@@ -1,0 +1,29 @@
+package com.jessitron;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = ChangeMeApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+public class SurveyWebIntegrationTests {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    public void surveyTest() {
+        Int seed = "123";
+        ResponseEntity<Survey> result = restTemplate.getForEntity("/survey?seed={_}", Survey.class, seed);
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals(seed, result.getBody().getSeed());
+    }
+}


### PR DESCRIPTION
Created by Atomist Editor `AddRestEndpoint`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "AddRestEndpoint"
  group: "satellite-of-love"
  artifact: "rest-service-generator"
  version: "0.12.5"
  origin:
    repo: "git@github.com:satellite-of-love/rest-service-generator"
    branch: "master"
    sha: "89b8555"
  parameters:
    - "returnedClass": "Survey"
    - "fieldName": "seed"
    - "fieldType": "Int"
    - "repo": "atomist-k8-specs"
    - "handle": "{}"
    - "__mappedParameters": "{"0":{"localKey":"repo","foreignKey":"atomist://github/repository"}}"
    - "__parameters": "{"0":{"displayName":"Java return type","description":"type the endpoint will return","pattern":"@java_class","validInput":"Java class name like ThunderCougarFalconBird","minLength":1,"maxLength":100,"name":"returnedClass","decorated":true},"1":{"displayName":"pojo field name","description":"name of a field in your pojo, blank for none (or not a new pojo)","pattern":"@java_identifier","validInput":"Java identifier","minLength":1,"maxLength":100,"name":"fieldName","decorated":true},"2":{"displayName":"pojo field type","description":"type of that field in your pojo, blank for none (or not a new pojo)","pattern":"@any","validInput":"Java type","minLength":1,"maxLength":100,"name":"fieldType","decorated":true}}"
    - "__intent": "{"0":"add endpoint"}"
    - "__tags": "{"0":"satellite-of-love","1":"rest"}"
    - "__name": "AddRestEndpointPlease"
    - "__description": "run an editor to add a REST endpoint to this project"
    - "__kind": "command-handler"

```