### PR TITLE
set up a satellite-of-love REST service on Travis

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -118,3 +118,19 @@ editor:
     branch: "master"
     sha: "5620b67*"
 
+---
+kind: "operation"
+client: "atomist-bot"
+editor:
+  name: "AddDeploymentSpec"
+  group: "satellite-of-love"
+  artifact: "rest-service-generator"
+  version: "0.12.6"
+  origin:
+    repo: "git@github.com:satellite-of-love/rest-service-generator"
+    branch: "master"
+    sha: "c6cb6ad"
+  parameters:
+    - "service": "panda-panda"
+    - "path": "kittiesplease"
+

--- a/60-panda-panda-svc.json
+++ b/60-panda-panda-svc.json
@@ -1,0 +1,28 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "panda-panda",
+	"annotations": {
+	  "atomist.dnsmode" : "vanity",
+          "atomist.elb-service-name" : "kong",
+          "atomist.upstream_url" : "http://panda-panda:8080",
+          "atomist.vanity-name" : "survey.atomist.com",
+          "atomist.request_path": "/kittiesplease"
+	}
+    },
+    "spec": {
+        "selector": {
+            "app": "panda-panda"
+        },
+        "ports": [
+            {
+                "name": "panda-panda",
+                "protocol": "TCP",
+                "port": 8080,
+                "targetPort": 8080
+            }
+        ]
+    }
+}
+ 

--- a/80-panda-panda-deployment.json
+++ b/80-panda-panda-deployment.json
@@ -1,0 +1,59 @@
+{
+  "apiVersion" : "extensions/v1beta1",
+  "kind" : "Deployment",
+  "metadata" : {
+    "name" : "panda-panda"
+  },
+  "spec" : {
+    "replicas" : 1,
+    "revisionHistoryLimit" : 3,
+    "selector" : {
+      "matchLabels" : {
+        "app" : "panda-panda"
+      }
+    },
+    "template" : {
+      "metadata" : {
+        "name" : "panda-panda",
+        "labels" : {
+          "app" : "panda-panda"
+        },
+        "annotations" : {
+          "atomist.config" : "{}",
+          "atomist.updater" : "{sforzando-docker-dockerv2-local.artifactoryonline.com/panda-panda satellite-of-love/panda-panda}"
+        }
+      },
+      "spec" : {
+        "containers" : [ {
+          "name" : "panda-panda",
+          "image" : "sforzando-docker-dockerv2-local.artifactoryonline.com/panda-panda:0.1.0-SNAPSHOT",
+          "imagePullPolicy" : "Always",
+          "resources" : {
+            "limits" : {
+              "cpu" : 0.5,
+              "memory" : "512Mi"
+            },
+            "requests" : {
+              "cpu" : 0.1,
+              "memory" : "256Mi"
+            }
+          },
+          "env" : [],
+          "ports" : [ {
+            "containerPort" : 8080
+          } ]
+        } ],
+        "imagePullSecrets" : [ {
+          "name" : "atomistregistrykey"
+        } ]
+      }
+    },
+    "strategy" : {
+      "type" : "RollingUpdate",
+      "rollingUpdate" : {
+        "maxUnavailable" : 0,
+        "maxSurge" : 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
Say hello to a new service, panda-panda
        
        Merge this PR only after the Travis build has published some artifact for this service, please.

Created by Atomist Editor `AddDeploymentSpec`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "AddDeploymentSpec"
  group: "satellite-of-love"
  artifact: "rest-service-generator"
  version: "0.12.6"
  origin:
    repo: "git@github.com:satellite-of-love/rest-service-generator"
    branch: "master"
    sha: "c6cb6ad"
  parameters:
    - "service": "panda-panda"
    - "path": "kittiesplease"

```