### PR TITLE
set up a satellite-of-love REST service on Travis

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -134,3 +134,19 @@ editor:
     - "service": "panda-panda"
     - "path": "kittiesplease"
 
+---
+kind: "operation"
+client: "atomist-bot"
+editor:
+  name: "AddDeploymentSpec"
+  group: "satellite-of-love"
+  artifact: "rest-service-generator"
+  version: "0.12.6"
+  origin:
+    repo: "git@github.com:satellite-of-love/rest-service-generator"
+    branch: "master"
+    sha: "c6cb6ad"
+  parameters:
+    - "service": "kittypalooza"
+    - "path": "kittiesplease"
+

--- a/60-kittypalooza-svc.json
+++ b/60-kittypalooza-svc.json
@@ -1,0 +1,28 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "kittypalooza",
+	"annotations": {
+	  "atomist.dnsmode" : "vanity",
+          "atomist.elb-service-name" : "kong",
+          "atomist.upstream_url" : "http://kittypalooza:8080",
+          "atomist.vanity-name" : "survey.atomist.com",
+          "atomist.request_path": "/kittiesplease"
+	}
+    },
+    "spec": {
+        "selector": {
+            "app": "kittypalooza"
+        },
+        "ports": [
+            {
+                "name": "kittypalooza",
+                "protocol": "TCP",
+                "port": 8080,
+                "targetPort": 8080
+            }
+        ]
+    }
+}
+ 

--- a/80-kittypalooza-deployment.json
+++ b/80-kittypalooza-deployment.json
@@ -1,0 +1,59 @@
+{
+  "apiVersion" : "extensions/v1beta1",
+  "kind" : "Deployment",
+  "metadata" : {
+    "name" : "kittypalooza"
+  },
+  "spec" : {
+    "replicas" : 1,
+    "revisionHistoryLimit" : 3,
+    "selector" : {
+      "matchLabels" : {
+        "app" : "kittypalooza"
+      }
+    },
+    "template" : {
+      "metadata" : {
+        "name" : "kittypalooza",
+        "labels" : {
+          "app" : "kittypalooza"
+        },
+        "annotations" : {
+          "atomist.config" : "{}",
+          "atomist.updater" : "{sforzando-docker-dockerv2-local.artifactoryonline.com/kittypalooza satellite-of-love/kittypalooza}"
+        }
+      },
+      "spec" : {
+        "containers" : [ {
+          "name" : "kittypalooza",
+          "image" : "sforzando-docker-dockerv2-local.artifactoryonline.com/kittypalooza:0.1.0-SNAPSHOT",
+          "imagePullPolicy" : "Always",
+          "resources" : {
+            "limits" : {
+              "cpu" : 0.5,
+              "memory" : "512Mi"
+            },
+            "requests" : {
+              "cpu" : 0.1,
+              "memory" : "256Mi"
+            }
+          },
+          "env" : [],
+          "ports" : [ {
+            "containerPort" : 8080
+          } ]
+        } ],
+        "imagePullSecrets" : [ {
+          "name" : "atomistregistrykey"
+        } ]
+      }
+    },
+    "strategy" : {
+      "type" : "RollingUpdate",
+      "rollingUpdate" : {
+        "maxUnavailable" : 0,
+        "maxSurge" : 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
Say hello to a new service, kittypalooza
        
        Merge this PR only after the Travis build has published some artifact for this service, please.

Created by Atomist Editor `AddDeploymentSpec`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "AddDeploymentSpec"
  group: "satellite-of-love"
  artifact: "rest-service-generator"
  version: "0.12.6"
  origin:
    repo: "git@github.com:satellite-of-love/rest-service-generator"
    branch: "master"
    sha: "c6cb6ad"
  parameters:
    - "service": "kittypalooza"
    - "path": "kittiesplease"

```