### PR TITLE
set up a satellite-of-love REST service on Travis

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -166,3 +166,19 @@ editor:
     - "service": "james-kitties"
     - "path": "auckland"
 
+---
+kind: "operation"
+client: "atomist-bot"
+editor:
+  name: "AddDeploymentSpec"
+  group: "satellite-of-love"
+  artifact: "rest-service-generator"
+  version: "1.1.1"
+  origin:
+    repo: "git@github.com:satellite-of-love/rest-service-generator"
+    branch: "master"
+    sha: "c56af85"
+  parameters:
+    - "service": "kipz-test-2"
+    - "path": "kipzies"
+

--- a/60-kipz-test-2-svc.json
+++ b/60-kipz-test-2-svc.json
@@ -1,0 +1,28 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "kipz-test-2",
+	"annotations": {
+	  "atomist.dnsmode" : "vanity",
+          "atomist.elb-service-name" : "kong",
+          "atomist.upstream_url" : "http://kipz-test-2:8080",
+          "atomist.vanity-name" : "survey.atomist.com",
+          "atomist.request_path": "/kipzies"
+	}
+    },
+    "spec": {
+        "selector": {
+            "app": "kipz-test-2"
+        },
+        "ports": [
+            {
+                "name": "kipz-test-2",
+                "protocol": "TCP",
+                "port": 8080,
+                "targetPort": 8080
+            }
+        ]
+    }
+}
+ 

--- a/80-kipz-test-2-deployment.json
+++ b/80-kipz-test-2-deployment.json
@@ -1,0 +1,59 @@
+{
+  "apiVersion" : "extensions/v1beta1",
+  "kind" : "Deployment",
+  "metadata" : {
+    "name" : "kipz-test-2"
+  },
+  "spec" : {
+    "replicas" : 1,
+    "revisionHistoryLimit" : 3,
+    "selector" : {
+      "matchLabels" : {
+        "app" : "kipz-test-2"
+      }
+    },
+    "template" : {
+      "metadata" : {
+        "name" : "kipz-test-2",
+        "labels" : {
+          "app" : "kipz-test-2"
+        },
+        "annotations" : {
+          "atomist.config" : "{}",
+          "atomist.updater" : "{sforzando-docker-dockerv2-local.artifactoryonline.com/kipz-test-2 satellite-of-love/kipz-test-2}"
+        }
+      },
+      "spec" : {
+        "containers" : [ {
+          "name" : "kipz-test-2",
+          "image" : "sforzando-docker-dockerv2-local.artifactoryonline.com/kipz-test-2:0.1.0-SNAPSHOT",
+          "imagePullPolicy" : "Always",
+          "resources" : {
+            "limits" : {
+              "cpu" : 0.5,
+              "memory" : "512Mi"
+            },
+            "requests" : {
+              "cpu" : 0.1,
+              "memory" : "256Mi"
+            }
+          },
+          "env" : [],
+          "ports" : [ {
+            "containerPort" : 8080
+          } ]
+        } ],
+        "imagePullSecrets" : [ {
+          "name" : "atomistregistrykey"
+        } ]
+      }
+    },
+    "strategy" : {
+      "type" : "RollingUpdate",
+      "rollingUpdate" : {
+        "maxUnavailable" : 0,
+        "maxSurge" : 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
Say hello to a new service, kipz-test-2
        
        Merge this PR only after the Travis build has published some artifact for this service, please.

Created by Atomist Editor `AddDeploymentSpec`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "AddDeploymentSpec"
  group: "satellite-of-love"
  artifact: "rest-service-generator"
  version: "1.1.1"
  origin:
    repo: "git@github.com:satellite-of-love/rest-service-generator"
    branch: "master"
    sha: "c56af85"
  parameters:
    - "service": "kipz-test-2"
    - "path": "kipzies"

```