### PR TITLE
set up a satellite-of-love REST service on Travis

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -44,3 +44,16 @@ editor:
     branch: "master"
     sha: "c23ed53"
 
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170602144934"
+editor:
+  name: "AddDeploymentSpec"
+  group: "satellite-of-love"
+  artifact: "rest-service-generator"
+  version: "1.10.0"
+  parameters:
+    - "service": "toes"
+    - "path": "toes"
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.atomist.yml linguist-generated=true

--- a/60-toes-svc.json
+++ b/60-toes-svc.json
@@ -1,0 +1,28 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "toes",
+	"annotations": {
+	  "atomist.dnsmode" : "vanity",
+          "atomist.elb-service-name" : "kong",
+          "atomist.upstream_url" : "http://toes:8080",
+          "atomist.vanity-name" : "survey.atomist.com",
+          "atomist.request_path": "/toes"
+	}
+    },
+    "spec": {
+        "selector": {
+            "app": "toes"
+        },
+        "ports": [
+            {
+                "name": "toes",
+                "protocol": "TCP",
+                "port": 8080,
+                "targetPort": 8080
+            }
+        ]
+    }
+}
+ 

--- a/80-toes-deployment.json
+++ b/80-toes-deployment.json
@@ -1,0 +1,59 @@
+{
+  "apiVersion" : "extensions/v1beta1",
+  "kind" : "Deployment",
+  "metadata" : {
+    "name" : "toes"
+  },
+  "spec" : {
+    "replicas" : 1,
+    "revisionHistoryLimit" : 3,
+    "selector" : {
+      "matchLabels" : {
+        "app" : "toes"
+      }
+    },
+    "template" : {
+      "metadata" : {
+        "name" : "toes",
+        "labels" : {
+          "app" : "toes"
+        },
+        "annotations" : {
+          "atomist.config" : "{}",
+          "atomist.updater" : "{sforzando-docker-dockerv2-local.artifactoryonline.com/toes satellite-of-love/toes}"
+        }
+      },
+      "spec" : {
+        "containers" : [ {
+          "name" : "toes",
+          "image" : "sforzando-docker-dockerv2-local.artifactoryonline.com/toes:0.1.0-SNAPSHOT",
+          "imagePullPolicy" : "Always",
+          "resources" : {
+            "limits" : {
+              "cpu" : 0.5,
+              "memory" : "512Mi"
+            },
+            "requests" : {
+              "cpu" : 0.1,
+              "memory" : "256Mi"
+            }
+          },
+          "env" : [],
+          "ports" : [ {
+            "containerPort" : 8080
+          } ]
+        } ],
+        "imagePullSecrets" : [ {
+          "name" : "atomistregistrykey"
+        } ]
+      }
+    },
+    "strategy" : {
+      "type" : "RollingUpdate",
+      "rollingUpdate" : {
+        "maxUnavailable" : 0,
+        "maxSurge" : 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
Say hello to a new service, toes
        
        Merge this PR only after the Travis build has published some artifact for this service, please.

Created by Atomist Editor `AddDeploymentSpec`
```
---
kind: "operation"
client: "com.atomist:rug"
version: "1.0.0-20170602144934"
editor:
  name: "AddDeploymentSpec"
  group: "satellite-of-love"
  artifact: "rest-service-generator"
  version: "1.10.0"
  parameters:
    - "service": "toes"
    - "path": "toes"

```